### PR TITLE
:recycle: #31 ヘッダーを共通コンポーネントAppHeaderに置き換え

### DIFF
--- a/apps/web/src/app/categories/page.tsx
+++ b/apps/web/src/app/categories/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { ArrowLeft, Plus, X, Check } from "lucide-react";
+import { Plus, X, Check } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/contexts/ToastContext";
 import { Input } from "@/components/ui/input";
-import { Link } from "@/components/ui/link";
 import { Loading } from "@/components/ui/loading";
+import { AppHeader } from "@/components/AppHeader";
 import {
   getCategories,
   postCategories,
@@ -270,21 +270,15 @@ const CategoriesPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <header className="sticky top-0 z-30 flex h-16 items-center justify-between gap-4 border-b bg-white dark:bg-gray-800 px-4 sm:px-6">
-        <Link href="/" variant="ghost">
-          <ArrowLeft className="h-5 w-5" />
-          <span>ダッシュボードに戻る</span>
-        </Link>
-        <div className="flex items-center gap-4">
-          <Link href="/expenses" variant="outline">
-            支出一覧
-          </Link>
+      <AppHeader
+        currentPath="/categories"
+        actions={
           <Button variant="brand" onClick={startCreate}>
             <Plus className="h-4 w-4" />
             新規作成
           </Button>
-        </div>
-      </header>
+        }
+      />
 
       <main className="max-w-4xl mx-auto p-6">
         <div className="mb-8">

--- a/apps/web/src/app/expenses/page.tsx
+++ b/apps/web/src/app/expenses/page.tsx
@@ -5,23 +5,10 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SelectNative } from "@/components/ui/select-native";
-import { Link } from "@/components/ui/link";
 import { Loading } from "@/components/ui/loading";
-import {
-  Search,
-  ChevronDown,
-  ChevronUp,
-  LogOut,
-  Upload,
-  Filter,
-  Pencil,
-  Check,
-  X,
-  PlusCircle,
-  Trash2,
-} from "lucide-react";
-import { useAuth } from "@/contexts/AuthContext";
+import { Search, ChevronDown, ChevronUp, Filter, Pencil, Check, X, PlusCircle, Trash2 } from "lucide-react";
 import { useToast } from "@/contexts/ToastContext";
+import { AppHeader } from "@/components/AppHeader";
 import { ManualEntryModal } from "@/components/expenses/ManualEntryModal";
 import {
   getTransactions,
@@ -43,7 +30,6 @@ import type { TransactionResponse as Transaction, CategoryResponse as CategoryWi
  * @returns The ExpensesPage React element.
  */
 const ExpensesPage = () => {
-  const { user, logout } = useAuth();
   const { success, error: toastError } = useToast();
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [categories, setCategories] = useState<CategoryWithSystem[]>([]);
@@ -126,10 +112,6 @@ const ExpensesPage = () => {
   useEffect(() => {
     fetchTransactions();
   }, [fetchTransactions]);
-
-  const handleLogout = async () => {
-    await logout();
-  };
 
   const handleSort = (column: "date" | "amount") => {
     if (sortBy === column) {
@@ -234,40 +216,15 @@ const ExpensesPage = () => {
 
   return (
     <div className="flex min-h-screen flex-col bg-muted/10">
-      <header className="sticky top-0 z-30 flex h-16 items-center justify-between gap-4 border-b bg-background px-4 sm:px-6">
-        <div className="flex items-center gap-3">
-          <Link href="/" className="flex items-center gap-3">
-            <div className="w-8 h-8 bg-linear-to-br from-red-500 to-pink-600 rounded-lg flex items-center justify-center">
-              <span className="text-white font-bold text-sm">¥</span>
-            </div>
-            <h1 className="text-xl font-bold tracking-tight">PayPay 家計簿</h1>
-          </Link>
-        </div>
-        <div className="flex items-center gap-2 sm:gap-4">
-          <Link href="/expenses" variant="outline" className="text-red-600 bg-red-50 dark:bg-red-900/20">
-            支出一覧
-          </Link>
-          <Link href="/categories" variant="outline">
-            カテゴリ
-          </Link>
-          <Link href="/rules" variant="outline">
-            ルール
-          </Link>
-          <Link href="/upload" variant="brand">
-            <Upload className="h-4 w-4" />
-            <span className="hidden sm:inline">CSV アップロード</span>
-          </Link>
+      <AppHeader
+        currentPath="/expenses"
+        actions={
           <Button variant="outline" onClick={() => setIsModalOpen(true)}>
             <PlusCircle className="h-4 w-4" />
             <span className="hidden sm:inline">手動入力</span>
           </Button>
-          <span className="text-sm text-muted-foreground hidden sm:block">{user?.name}</span>
-          <Button variant="ghost" onClick={handleLogout}>
-            <LogOut className="h-4 w-4" />
-            <span className="hidden sm:block">ログアウト</span>
-          </Button>
-        </div>
-      </header>
+        }
+      />
 
       <main className="flex-1 p-4 sm:px-6 sm:py-6 space-y-6">
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -6,10 +6,9 @@ import { AnnualExpenseBarChart } from "@/components/charts/AnnualExpenseBarChart
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { SelectNative } from "@/components/ui/select-native";
-import { Link } from "@/components/ui/link";
 import { Loading } from "@/components/ui/loading";
-import { DollarSign, TrendingUp, Wallet, LogOut, Upload, PlusCircle } from "lucide-react";
-import { useAuth } from "@/contexts/AuthContext";
+import { DollarSign, TrendingUp, Wallet, PlusCircle } from "lucide-react";
+import { AppHeader } from "@/components/AppHeader";
 import { ManualEntryModal } from "@/components/expenses/ManualEntryModal";
 import { getTransactionsSummary, getTransactionsAvailableYears } from "@/api/generated/transactions/transactions";
 import type {
@@ -27,7 +26,6 @@ import type {
  * @returns The React element that renders the full dashboard interface including controls, charts, and the ManualEntryModal.
  */
 const Dashboard = () => {
-  const { user, logout } = useAuth();
   const [summary, setSummary] = useState<SummaryResponse | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [availableYears, setAvailableYears] = useState<number[]>([]);
@@ -107,10 +105,6 @@ const Dashboard = () => {
 
   const topCategoryRatio = yearlyTotal > 0 && topCategory ? (topCategory.totalAmount / yearlyTotal) * 100 : 0;
 
-  const handleLogout = async () => {
-    await logout();
-  };
-
   const formatCurrency = (amount: number) => {
     return new Intl.NumberFormat("ja-JP", {
       style: "currency",
@@ -121,38 +115,15 @@ const Dashboard = () => {
 
   return (
     <div className="flex min-h-screen flex-col bg-muted/10">
-      <header className="sticky top-0 z-30 flex h-16 items-center justify-between gap-4 border-b bg-background px-4 sm:px-6">
-        <div className="flex items-center gap-3">
-          <div className="w-8 h-8 bg-linear-to-br from-red-500 to-pink-600 rounded-lg flex items-center justify-center">
-            <span className="text-white font-bold text-sm">¥</span>
-          </div>
-          <h1 className="text-xl font-bold tracking-tight">PayPay 家計簿</h1>
-        </div>
-        <div className="flex items-center gap-2 sm:gap-4">
-          <Link href="/expenses" variant="outline">
-            支出一覧
-          </Link>
-          <Link href="/categories" variant="outline">
-            カテゴリ
-          </Link>
-          <Link href="/rules" variant="outline">
-            ルール
-          </Link>
-          <Link href="/upload" variant="brand">
-            <Upload className="h-4 w-4" />
-            <span className="hidden sm:inline">CSV アップロード</span>
-          </Link>
+      <AppHeader
+        currentPath="/"
+        actions={
           <Button variant="outline" onClick={() => setIsModalOpen(true)}>
             <PlusCircle className="h-4 w-4" />
             <span className="hidden sm:inline">手動入力</span>
           </Button>
-          <span className="text-sm text-muted-foreground hidden sm:block">{user?.name}</span>
-          <Button variant="ghost" onClick={handleLogout}>
-            <LogOut className="h-4 w-4" />
-            <span className="hidden sm:block">ログアウト</span>
-          </Button>
-        </div>
-      </header>
+        }
+      />
 
       <main className="grid flex-1 items-start gap-4 p-4 sm:px-6 sm:py-6 md:gap-8">
         {/* 年選択ドロップダウン */}

--- a/apps/web/src/app/rules/page.tsx
+++ b/apps/web/src/app/rules/page.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { ArrowLeft, Plus, Pencil, Trash2, X, Check, RefreshCw } from "lucide-react";
+import { Plus, Pencil, Trash2, X, Check, RefreshCw } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/contexts/ToastContext";
 import { Input } from "@/components/ui/input";
 import { SelectNative } from "@/components/ui/select-native";
-import { Link } from "@/components/ui/link";
 import { Loading } from "@/components/ui/loading";
+import { AppHeader } from "@/components/AppHeader";
 import { getRules, postRules, putRulesId, deleteRulesId } from "@/api/generated/rules/rules";
 import { getCategories } from "@/api/generated/categories/categories";
 import { postTransactionsReCategorize } from "@/api/generated/transactions/transactions";
@@ -190,15 +190,9 @@ const RulesPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <header className="sticky top-0 z-30 flex h-16 items-center justify-between gap-4 border-b bg-white dark:bg-gray-800 px-4 sm:px-6">
-        <Link href="/" variant="ghost">
-          <ArrowLeft className="h-5 w-5" />
-          <span>ダッシュボードに戻る</span>
-        </Link>
-        <div className="flex items-center gap-4">
-          <Link href="/expenses" variant="outline">
-            支出一覧
-          </Link>
+      <AppHeader
+        currentPath="/rules"
+        actions={
           <div className="flex gap-2">
             <Button variant="outline" onClick={handleReCategorize} disabled={isReCategorizing}>
               <RefreshCw className={`h-4 w-4 ${isReCategorizing ? "animate-spin" : ""}`} />
@@ -209,8 +203,8 @@ const RulesPage = () => {
               新規作成
             </Button>
           </div>
-        </div>
-      </header>
+        }
+      />
 
       <main className="max-w-4xl mx-auto p-6">
         <div className="mb-8">

--- a/apps/web/src/app/upload/page.tsx
+++ b/apps/web/src/app/upload/page.tsx
@@ -2,10 +2,10 @@
 
 import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { Upload, ArrowLeft, FileText, CheckCircle, AlertCircle } from "lucide-react";
+import { Upload, FileText, CheckCircle, AlertCircle } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Link } from "@/components/ui/link";
+import { AppHeader } from "@/components/AppHeader";
 import { postTransactionsUpload, type postTransactionsUploadResponse } from "@/api/generated/transactions/transactions";
 
 type UploadStatus = "idle" | "uploading" | "success" | "error";
@@ -102,15 +102,7 @@ const UploadPage = () => {
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <header className="sticky top-0 z-30 flex h-16 items-center gap-4 border-b bg-white dark:bg-gray-800 px-4 sm:px-6">
-        <Link href="/" variant="ghost">
-          <ArrowLeft className="h-5 w-5" />
-          <span>ダッシュボードに戻る</span>
-        </Link>
-        <Link href="/expenses" variant="outline">
-          支出一覧
-        </Link>
-      </header>
+      <AppHeader currentPath="/upload" />
 
       <main className="max-w-2xl mx-auto p-6">
         <div className="mb-8">

--- a/apps/web/src/components/AppHeader.test.tsx
+++ b/apps/web/src/components/AppHeader.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AppHeader } from "./AppHeader";
+import { AuthProvider } from "@/contexts/AuthContext";
+import type { User } from "@/api/models";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/",
+}));
+
+// Mock next/link
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: { children: React.ReactNode; href: string; [key: string]: unknown }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Mock API functions
+const mockGetAuthMe = vi.fn();
+const mockPostAuthLogout = vi.fn();
+
+vi.mock("@/api/generated/auth/auth", () => ({
+  getAuthMe: () => mockGetAuthMe(),
+  postAuthLogout: () => mockPostAuthLogout(),
+}));
+
+const mockUser: User = {
+  id: "user-123",
+  name: "テストユーザー",
+  email: "test@example.com",
+};
+
+const renderWithAuth = (ui: React.ReactNode) => {
+  mockGetAuthMe.mockResolvedValue({ status: 200, data: mockUser });
+  return render(<AuthProvider>{ui}</AuthProvider>);
+};
+
+describe("AppHeader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("ロゴとブランド", () => {
+    it("PayPay 家計簿のロゴテキストを表示する", () => {
+      renderWithAuth(<AppHeader />);
+      expect(screen.getByText("PayPay 家計簿")).toBeInTheDocument();
+    });
+
+    it("¥アイコンを表示する", () => {
+      renderWithAuth(<AppHeader />);
+      expect(screen.getByText("¥")).toBeInTheDocument();
+    });
+
+    it("currentPath='/' の場合ロゴがリンクでない", () => {
+      renderWithAuth(<AppHeader currentPath="/" />);
+      const logo = screen.getByText("PayPay 家計簿");
+      // h1 は直接の親でリンクに囲まれていない
+      expect(logo.closest("a")).toBeNull();
+    });
+
+    it("currentPath が '/' 以外の場合ロゴがリンクになる", () => {
+      renderWithAuth(<AppHeader currentPath="/expenses" />);
+      const logo = screen.getByText("PayPay 家計簿");
+      const link = logo.closest("a");
+      expect(link).not.toBeNull();
+      expect(link?.getAttribute("href")).toBe("/");
+    });
+  });
+
+  describe("ナビゲーションリンク", () => {
+    it("支出一覧リンクを表示する", () => {
+      renderWithAuth(<AppHeader />);
+      expect(screen.getByText("支出一覧")).toBeInTheDocument();
+    });
+
+    it("カテゴリリンクを表示する", () => {
+      renderWithAuth(<AppHeader />);
+      expect(screen.getByText("カテゴリ")).toBeInTheDocument();
+    });
+
+    it("ルールリンクを表示する", () => {
+      renderWithAuth(<AppHeader />);
+      expect(screen.getByText("ルール")).toBeInTheDocument();
+    });
+
+    it("現在のパスのリンクにハイライトクラスが適用される", () => {
+      renderWithAuth(<AppHeader currentPath="/expenses" />);
+      const expensesLink = screen.getByText("支出一覧").closest("a");
+      expect(expensesLink?.className).toContain("text-red-600");
+    });
+
+    it("現在のパスでないリンクにはハイライトクラスが適用されない", () => {
+      renderWithAuth(<AppHeader currentPath="/expenses" />);
+      const categoriesLink = screen.getByText("カテゴリ").closest("a");
+      expect(categoriesLink?.className).not.toContain("text-red-600");
+    });
+  });
+
+  describe("CSV アップロードリンク", () => {
+    it("CSV アップロードリンクを表示する", () => {
+      renderWithAuth(<AppHeader />);
+      expect(screen.getByText("CSV アップロード")).toBeInTheDocument();
+    });
+
+    it("currentPath='/categories' の場合は CSV アップロードを非表示にする", () => {
+      renderWithAuth(<AppHeader currentPath="/categories" />);
+      expect(screen.queryByText("CSV アップロード")).not.toBeInTheDocument();
+    });
+
+    it("currentPath='/rules' の場合は CSV アップロードを非表示にする", () => {
+      renderWithAuth(<AppHeader currentPath="/rules" />);
+      expect(screen.queryByText("CSV アップロード")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("actions prop", () => {
+    it("actions を渡すとレンダリングされる", () => {
+      renderWithAuth(<AppHeader actions={<button data-testid="custom-action">カスタムアクション</button>} />);
+      expect(screen.getByTestId("custom-action")).toBeInTheDocument();
+      expect(screen.getByText("カスタムアクション")).toBeInTheDocument();
+    });
+
+    it("actions を渡さない場合もエラーにならない", () => {
+      renderWithAuth(<AppHeader />);
+      // ヘッダーが正常にレンダリングされている
+      expect(screen.getByText("PayPay 家計簿")).toBeInTheDocument();
+    });
+  });
+
+  describe("ログアウトボタン", () => {
+    it("ログアウトボタンを表示する", () => {
+      renderWithAuth(<AppHeader />);
+      expect(screen.getByText("ログアウト")).toBeInTheDocument();
+    });
+
+    it("ログアウトボタンクリックで logout が呼ばれる", async () => {
+      mockPostAuthLogout.mockResolvedValue({ status: 200 });
+
+      renderWithAuth(<AppHeader />);
+
+      const user = userEvent.setup();
+      const logoutButton = screen.getByText("ログアウト");
+      await user.click(logoutButton);
+
+      expect(mockPostAuthLogout).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useAuth } from "@/contexts/AuthContext";
+import { Link } from "@/components/ui/link";
+import { Button } from "@/components/ui/button";
+import { LogOut, Upload } from "lucide-react";
+
+type AppHeaderProps = {
+  /** 右側に表示するページ固有のアクションボタン群 */
+  actions?: React.ReactNode;
+  /** 現在のページパス（ナビリンクのハイライト用） */
+  currentPath?: string;
+};
+
+const NAV_LINKS = [
+  { href: "/expenses", label: "支出一覧" },
+  { href: "/categories", label: "カテゴリ" },
+  { href: "/rules", label: "ルール" },
+] as const;
+
+/**
+ * アプリ全体で使用する共通ヘッダーコンポーネント。
+ *
+ * ロゴ、ナビゲーションリンク、CSVアップロードリンク、ページ固有アクション、
+ * ユーザー名表示、ログアウトボタンを含む。
+ */
+export const AppHeader = ({ actions, currentPath }: AppHeaderProps) => {
+  const { user, logout } = useAuth();
+
+  const handleLogout = async () => {
+    await logout();
+  };
+
+  return (
+    <header className="sticky top-0 z-30 flex h-16 items-center justify-between gap-4 border-b bg-background px-4 sm:px-6">
+      <div className="flex items-center gap-3">
+        {currentPath === "/" ? (
+          <>
+            <div className="w-8 h-8 bg-linear-to-br from-red-500 to-pink-600 rounded-lg flex items-center justify-center">
+              <span className="text-white font-bold text-sm">¥</span>
+            </div>
+            <h1 className="text-xl font-bold tracking-tight">PayPay 家計簿</h1>
+          </>
+        ) : (
+          <Link href="/" className="flex items-center gap-3">
+            <div className="w-8 h-8 bg-linear-to-br from-red-500 to-pink-600 rounded-lg flex items-center justify-center">
+              <span className="text-white font-bold text-sm">¥</span>
+            </div>
+            <h1 className="text-xl font-bold tracking-tight">PayPay 家計簿</h1>
+          </Link>
+        )}
+      </div>
+      <div className="flex items-center gap-2 sm:gap-4">
+        {NAV_LINKS.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            variant="outline"
+            className={currentPath === link.href ? "text-red-600 bg-red-50 dark:bg-red-900/20" : ""}
+          >
+            {link.label}
+          </Link>
+        ))}
+        {currentPath !== "/categories" && currentPath !== "/rules" && (
+          <Link
+            href="/upload"
+            variant="brand"
+            className={currentPath === "/upload" ? "opacity-80 ring-2 ring-red-300" : ""}
+          >
+            <Upload className="h-4 w-4" />
+            <span className="hidden sm:inline">CSV アップロード</span>
+          </Link>
+        )}
+        {actions}
+        <span className="text-sm text-muted-foreground hidden sm:block">{user?.name}</span>
+        <Button variant="ghost" onClick={handleLogout}>
+          <LogOut className="h-4 w-4" />
+          <span className="hidden sm:block">ログアウト</span>
+        </Button>
+      </div>
+    </header>
+  );
+};


### PR DESCRIPTION
close #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified the application header across all pages for a more consistent user experience. Navigation links (expenses, categories, rules) now display uniformly with active state highlighting. User account controls and logout functionality are consolidated in the header. All existing page-specific action buttons remain fully functional.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->